### PR TITLE
Update default pip

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,7 +17,7 @@ api = "0.7"
   build = true
 
   [metadata.default-versions]
-    pip = "21.2.x"
+    pip = "23.3.x"
 
   [[metadata.dependencies]]
     checksum = "sha256:5f0622fdc984d4957cf5ece7d0641fa604c2187f3ddce9fe9ce0019d4d015f03"


### PR DESCRIPTION
See: https://github.com/plotly/dekn/issues/10687

Updates default pip to 23.3.x to match the python version (3.12)